### PR TITLE
feat(web): add awareness cursors and presence user list

### DIFF
--- a/docs/milestones/collaborative-editing-core/prs/06-awareness-and-cursors/implementation-plan.md
+++ b/docs/milestones/collaborative-editing-core/prs/06-awareness-and-cursors/implementation-plan.md
@@ -2,133 +2,81 @@
 
 ## Prerequisites
 
-- [ ] PR 4 merged (collaborative sync is working — `WebsocketProvider` and `Y.Doc` are connected)
-- [ ] PR 5 merged (toolbar exists, but this is a soft dependency — cursors work without the toolbar)
+- [x] PR 4 merged (collaborative sync is working — `WebsocketProvider` and `Y.Doc` are connected)
+- [x] PR 5 merged (toolbar exists, but this is a soft dependency — cursors work without the toolbar)
 
 ## Steps
 
 ### Step 1: Install Cursor Extension
 
-- [ ] Add `@tiptap/extension-collaboration-cursor` to `web/package.json` — Tiptap wrapper for y-prosemirror's cursor plugin
-- [ ] Run `pnpm install`
+- [x] ~~Add `@tiptap/extension-collaboration-cursor` to `web/package.json`~~ — used `yCursorPlugin` from `@tiptap/y-tiptap` directly (already a dependency), wrapped in a custom Tiptap extension. The v2 wrapper package is deprecated and incompatible with Tiptap v3.
+- [x] Run `pnpm install`
 
 ### Step 2: Generate Random User Identity
 
-- [ ] Create `web/src/user-identity.ts`
-- [ ] Define the color palette (12 distinct colors)
-- [ ] Define a word list for random names (20–30 adjectives, 20–30 nouns)
-- [ ] Export `getOrCreateUserIdentity()`:
+- [x] Create `web/src/user-identity.ts`
+- [x] Define the color palette (12 distinct colors)
+- [x] Define a word list for random names (20–30 adjectives, 20–30 nouns)
+- [x] Export `getOrCreateUserIdentity()`:
   - Check `localStorage` for a stored identity (`cadmus-user-name`, `cadmus-user-color`)
   - If not found, generate a random name (adjective + noun) and pick a random color
   - Store in `localStorage`
   - Return `{ name: string, color: string }`
-- [ ] Export `clearUserIdentity()` for testing purposes
+- [x] Export `clearUserIdentity()` for testing purposes
 
 ### Step 3: Add Collaboration Cursor Extension to the Editor
 
-- [ ] Modify `web/src/Editor.tsx`:
-  - Import `CollaborationCursor` from `@tiptap/extension-collaboration-cursor`
+- [x] Modify `web/src/Editor.tsx`:
+  - Import `CollaborationCursor` from custom `collaboration-cursor-extension.ts`
   - Import the user identity
-  - Add the cursor extension to the extensions array:
-    ```typescript
-    CollaborationCursor.configure({
-      provider,
-      user: { name: identity.name, color: identity.color },
-    });
-    ```
-  - The `provider` is the `WebsocketProvider` from the collaboration setup (PR 4)
+  - Add the cursor extension to the extensions array
+  - The `provider.awareness` is passed from the `WebsocketProvider` (PR 4)
 
 ### Step 4: Custom Cursor Renderer
 
-- [ ] Create `web/src/cursor-renderer.ts`
-- [ ] Export a `renderCursor` function matching the `CollaborationCursor` render API:
-
-  ```typescript
-  export function renderCursor(user: { name: string; color: string }) {
-    const cursor = document.createElement('span');
-    cursor.classList.add('collaboration-cursor');
-    cursor.style.borderColor = user.color;
-
-    const label = document.createElement('span');
-    label.classList.add('collaboration-cursor-label');
-    label.style.backgroundColor = user.color;
-    label.textContent = user.name;
-
-    cursor.appendChild(label);
-    return cursor;
-  }
-  ```
-
-- [ ] Pass this to the extension configuration: `render: renderCursor`
+- [x] Create `web/src/cursor-renderer.ts`
+- [x] Export a `cursorBuilder` function matching the `yCursorPlugin` builder API
+- [x] Pass this to the extension configuration: `cursorBuilder`
 
 ### Step 5: Add Cursor Styles
 
-- [ ] Add to `web/src/editor.css`:
-  - [ ] `.collaboration-cursor`: `border-left: 2px solid` (color set inline), `position: relative`
-  - [ ] `.collaboration-cursor-label`: `position: absolute`, `top: -1.4em`, `left: -1px`, `font-size: 0.75rem`, `color: white`, `padding: 1px 6px`, `border-radius: 3px`, `white-space: nowrap`, `pointer-events: none`, `opacity: 0` by default, `opacity: 1` on parent hover (or always visible — decide based on testing)
-  - [ ] `.yRemoteSelection`: background-color is set inline by the plugin
-  - [ ] `.yRemoteSelectionHead`: the cursor caret marker
+- [x] Add to `web/src/editor.css`:
+  - [x] `.collaboration-cursor`: `border-left: 2px solid` (color set inline), `position: relative`
+  - [x] `.collaboration-cursor-label`: `position: absolute`, `top: -1.4em`, `left: -1px`, `font-size: 0.75rem`, `color: white`, `padding: 1px 6px`, `border-radius: 3px`, `white-space: nowrap`, `pointer-events: none`, `opacity: 0` by default, `opacity: 1` on parent hover
+  - [x] `.yRemoteSelection`: background-color is set inline by the plugin
+  - [x] `.yRemoteSelectionHead`: the cursor caret marker
 
 ### Step 6: Create Presence User List Component
 
-- [ ] Create `web/src/Presence.tsx`
-- [ ] Accept `provider: WebsocketProvider` as a prop
-- [ ] Subscribe to `provider.awareness.on('change', ...)`
-- [ ] Read all awareness states: `provider.awareness.getStates()`
-- [ ] Filter to states that have a `user` field (skip entries without it)
-- [ ] Render a compact list:
-
-  ```tsx
-  export function Presence({ provider }: { provider: WebsocketProvider }) {
-    const [users, setUsers] = useState<{ name: string; color: string }[]>([]);
-
-    useEffect(() => {
-      const update = () => {
-        const states = Array.from(provider.awareness.getStates().values());
-        setUsers(
-          states.filter((s) => s.user).map((s) => s.user as { name: string; color: string }),
-        );
-      };
-      provider.awareness.on('change', update);
-      update(); // Initial read
-      return () => provider.awareness.off('change', update);
-    }, [provider]);
-
-    return (
-      <div className="presence" aria-label="Connected users">
-        {users.map((user, i) => (
-          <div key={i} className="presence-user" title={user.name}>
-            <span className="presence-dot" style={{ backgroundColor: user.color }} />
-            <span className="presence-name">{user.name}</span>
-          </div>
-        ))}
-      </div>
-    );
-  }
-  ```
+- [x] Create `web/src/Presence.tsx`
+- [x] Accept `provider: WebsocketProvider` as a prop
+- [x] Subscribe to `provider.awareness.on('change', ...)`
+- [x] Read all awareness states: `provider.awareness.getStates()`
+- [x] Filter to states that have a `user` field (skip entries without it)
+- [x] Render a compact list
 
 ### Step 7: Integrate Presence into the App
 
-- [ ] Modify `web/src/App.tsx`:
+- [x] Modify `web/src/App.tsx`:
   - Render `<Presence provider={provider} />` in the header, next to the connection status indicator
 
 ### Step 8: Add Presence Styles
 
-- [ ] Add to `web/src/editor.css`:
-  - [ ] `.presence`: flex row, gap, align items center
-  - [ ] `.presence-user`: flex row, gap, align items center
-  - [ ] `.presence-dot`: 10px circle, `border-radius: 50%`
-  - [ ] `.presence-name`: small font, truncate with ellipsis if needed
+- [x] Add to `web/src/editor.css`:
+  - [x] `.presence`: flex row, gap, align items center
+  - [x] `.presence-user`: flex row, gap, align items center
+  - [x] `.presence-dot`: 10px circle, `border-radius: 50%`
+  - [x] `.presence-name`: small font, truncate with ellipsis if needed
 
 ## Verification
 
-- [ ] Open two browser tabs. Each shows a different random name/color
-- [ ] Tab A's cursor is visible in Tab B (colored line + name label) and vice versa
-- [ ] Selecting text in Tab A shows a colored highlight in Tab B
-- [ ] The presence list in the header shows both users with correct colors
-- [ ] Closing Tab A causes its cursor to disappear from Tab B (after awareness timeout, ~30s)
-- [ ] Reloading a tab preserves the same user name and color (from localStorage)
-- [ ] Three or more tabs all see each other's cursors simultaneously
+- [x] Open two browser tabs. Each shows a different random name/color
+- [x] Tab A's cursor is visible in Tab B (colored line + name label) and vice versa
+- [x] Selecting text in Tab A shows a colored highlight in Tab B
+- [x] The presence list in the header shows both users with correct colors
+- [x] Closing Tab A causes its cursor to disappear from Tab B (after awareness timeout, ~30s)
+- [x] Reloading a tab preserves the same user name and color (from sessionStorage)
+- [x] Three or more tabs all see each other's cursors simultaneously
 
 ## Files Created/Modified
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -13,15 +13,15 @@
   "dependencies": {
     "@cadmus/doc-schema": "workspace:*",
     "@tiptap/core": "^3.7.0",
+    "@tiptap/extension-collaboration": "^3.7.0",
     "@tiptap/extension-image": "^3.7.0",
     "@tiptap/markdown": "^3.7.0",
     "@tiptap/pm": "^3.7.0",
     "@tiptap/react": "^3.7.0",
-    "@tiptap/extension-collaboration": "^3.7.0",
     "@tiptap/starter-kit": "^3.7.0",
+    "@tiptap/y-tiptap": "^3.0.2",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
-    "@tiptap/y-tiptap": "^3.0.2",
     "y-websocket": "^2.0.0",
     "yjs": "^13.6.0"
   },

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,4 +1,5 @@
 import { Editor } from './Editor';
+import { Presence } from './Presence';
 import { useCollaboration } from './useCollaboration';
 import { DEFAULT_DOC_ID } from './collaboration';
 
@@ -10,6 +11,7 @@ export function App() {
       <header className="app-header">
         <h1>Cadmus</h1>
         <span className={`status-dot ${connectionStatus}`} />
+        {provider && <Presence provider={provider} />}
       </header>
       <main className="app-main">
         {ydoc && provider && <Editor ydoc={ydoc} provider={provider} />}

--- a/packages/web/src/Editor.tsx
+++ b/packages/web/src/Editor.tsx
@@ -1,20 +1,28 @@
 import { useEditor, EditorContent } from '@tiptap/react';
 import { Collaboration } from '@tiptap/extension-collaboration';
+import { CollaborationCursor } from './collaboration-cursor-extension';
 import { createExtensions } from '@cadmus/doc-schema';
+import { getOrCreateUserIdentity } from './user-identity';
 import { Toolbar } from './Toolbar';
 import type * as Y from 'yjs';
 import type { WebsocketProvider } from 'y-websocket';
+
+const identity = getOrCreateUserIdentity();
 
 interface EditorProps {
   ydoc: Y.Doc;
   provider: WebsocketProvider;
 }
 
-export function Editor({ ydoc, provider: _provider }: EditorProps) {
+export function Editor({ ydoc, provider }: EditorProps) {
   const editor = useEditor({
     extensions: [
       ...createExtensions({ disableHistory: true }),
       Collaboration.configure({ document: ydoc }),
+      CollaborationCursor.configure({
+        awareness: provider.awareness,
+        user: identity,
+      }),
     ],
   });
 

--- a/packages/web/src/Presence.tsx
+++ b/packages/web/src/Presence.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+import type { WebsocketProvider } from 'y-websocket';
+
+interface PresenceUser {
+  name: string;
+  color: string;
+}
+
+export function Presence({ provider }: { provider: WebsocketProvider }) {
+  const [users, setUsers] = useState<PresenceUser[]>([]);
+
+  useEffect(() => {
+    const update = () => {
+      const states = Array.from(provider.awareness.getStates().values());
+      setUsers(states.filter((s) => s.user).map((s) => s.user as PresenceUser));
+    };
+
+    provider.awareness.on('change', update);
+    update();
+
+    return () => {
+      provider.awareness.off('change', update);
+    };
+  }, [provider]);
+
+  return (
+    <div className="presence" aria-label="Connected users">
+      {users.map((user, i) => (
+        <div key={i} className="presence-user" title={user.name}>
+          <span className="presence-dot" style={{ backgroundColor: user.color }} />
+          <span className="presence-name">{user.name}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/web/src/collaboration-cursor-extension.ts
+++ b/packages/web/src/collaboration-cursor-extension.ts
@@ -1,0 +1,30 @@
+import { Extension } from '@tiptap/core';
+import { yCursorPlugin } from '@tiptap/y-tiptap';
+import { cursorBuilder } from './cursor-renderer';
+import type { WebsocketProvider } from 'y-websocket';
+
+type Awareness = WebsocketProvider['awareness'];
+
+export interface CollaborationCursorOptions {
+  awareness: Awareness;
+  user: { name: string; color: string };
+}
+
+export const CollaborationCursor = Extension.create<CollaborationCursorOptions>({
+  name: 'collaborationCursor',
+
+  addOptions() {
+    return {
+      awareness: null as unknown as Awareness,
+      user: { name: 'Anonymous', color: '#aaaaaa' },
+    };
+  },
+
+  addProseMirrorPlugins() {
+    const { awareness, user } = this.options;
+
+    awareness.setLocalStateField('user', user);
+
+    return [yCursorPlugin(awareness, { cursorBuilder })];
+  },
+});

--- a/packages/web/src/cursor-renderer.ts
+++ b/packages/web/src/cursor-renderer.ts
@@ -1,0 +1,13 @@
+export function cursorBuilder(user: { name: string; color: string }): HTMLElement {
+  const cursor = document.createElement('span');
+  cursor.classList.add('collaboration-cursor');
+  cursor.style.borderColor = user.color;
+
+  const label = document.createElement('span');
+  label.classList.add('collaboration-cursor-label');
+  label.style.backgroundColor = user.color;
+  label.textContent = user.name;
+
+  cursor.appendChild(label);
+  return cursor;
+}

--- a/packages/web/src/editor.css
+++ b/packages/web/src/editor.css
@@ -277,3 +277,68 @@ body {
 .ProseMirror a:hover {
   color: #1d4ed8;
 }
+
+/* Collaboration cursors */
+.collaboration-cursor {
+  border-left: 2px solid;
+  position: relative;
+}
+
+.collaboration-cursor-label {
+  position: absolute;
+  top: -1.4em;
+  left: -1px;
+  font-size: 0.75rem;
+  color: white;
+  padding: 1px 6px;
+  border-radius: 3px;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+.collaboration-cursor:hover .collaboration-cursor-label {
+  opacity: 1;
+}
+
+/* Remote selection highlight (set inline by y-prosemirror) */
+.yRemoteSelection {
+  opacity: 0.35;
+}
+
+.yRemoteSelectionHead {
+  position: absolute;
+  border-left: 2px solid;
+  height: 1.2em;
+}
+
+/* Presence user list */
+.presence {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-left: auto;
+}
+
+.presence-user {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.presence-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.presence-name {
+  font-size: 0.8125rem;
+  color: #374151;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 120px;
+}

--- a/packages/web/src/user-identity.ts
+++ b/packages/web/src/user-identity.ts
@@ -1,0 +1,103 @@
+const COLORS = [
+  '#e06c75',
+  '#e5c07b',
+  '#98c379',
+  '#56b6c2',
+  '#61afef',
+  '#c678dd',
+  '#d19a66',
+  '#be5046',
+  '#7ec699',
+  '#f472b6',
+  '#a78bfa',
+  '#fb923c',
+];
+
+const ADJECTIVES = [
+  'Bold',
+  'Brave',
+  'Bright',
+  'Calm',
+  'Clever',
+  'Cool',
+  'Crimson',
+  'Daring',
+  'Eager',
+  'Fast',
+  'Fierce',
+  'Golden',
+  'Happy',
+  'Keen',
+  'Kind',
+  'Lively',
+  'Lucky',
+  'Noble',
+  'Quick',
+  'Sharp',
+  'Silent',
+  'Silver',
+  'Swift',
+  'Vivid',
+  'Wise',
+];
+
+const NOUNS = [
+  'Bear',
+  'Crane',
+  'Crow',
+  'Deer',
+  'Eagle',
+  'Falcon',
+  'Fox',
+  'Hawk',
+  'Heron',
+  'Lion',
+  'Lynx',
+  'Otter',
+  'Owl',
+  'Panda',
+  'Raven',
+  'Robin',
+  'Shark',
+  'Swan',
+  'Tiger',
+  'Whale',
+  'Wolf',
+  'Wren',
+];
+
+export interface UserIdentity {
+  name: string;
+  color: string;
+}
+
+const STORAGE_NAME_KEY = 'cadmus-user-name';
+const STORAGE_COLOR_KEY = 'cadmus-user-color';
+
+function pickRandom<T>(arr: T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+export function getOrCreateUserIdentity(): UserIdentity {
+  // Use sessionStorage so each tab gets its own identity,
+  // while still persisting across reloads of the same tab.
+  const storedName = sessionStorage.getItem(STORAGE_NAME_KEY);
+  const storedColor = sessionStorage.getItem(STORAGE_COLOR_KEY);
+
+  if (storedName && storedColor) {
+    return { name: storedName, color: storedColor };
+  }
+
+  const name = `${pickRandom(ADJECTIVES)} ${pickRandom(NOUNS)}`;
+  const color = pickRandom(COLORS);
+
+  sessionStorage.setItem(STORAGE_NAME_KEY, name);
+  sessionStorage.setItem(STORAGE_COLOR_KEY, color);
+
+  return { name, color };
+}
+
+export function clearUserIdentity(): void {
+  sessionStorage.removeItem(STORAGE_NAME_KEY);
+  sessionStorage.removeItem(STORAGE_COLOR_KEY);
+}


### PR DESCRIPTION
## Summary

- Add collaborative cursor rendering (colored cursor lines + name labels) and selection highlights using the Yjs awareness protocol
- Create a presence user list in the header showing all connected users with color dots
- Each tab generates a random identity (e.g. "Crimson Falcon") stored in `sessionStorage`, so multiple tabs appear as distinct users
- Use `yCursorPlugin` from `@tiptap/y-tiptap` wrapped in a custom Tiptap extension (avoids the deprecated `@tiptap/extension-collaboration-cursor` package)

## New files

- `packages/web/src/user-identity.ts` — random name/color generation with sessionStorage persistence
- `packages/web/src/cursor-renderer.ts` — custom cursor DOM builder
- `packages/web/src/collaboration-cursor-extension.ts` — Tiptap extension wrapping yCursorPlugin
- `packages/web/src/Presence.tsx` — real-time presence user list component

## Test plan

- [x] Open two browser tabs — each shows a different random name/color
- [x] Tab A's cursor is visible in Tab B (colored line + name label) and vice versa
- [x] Selecting text in Tab A shows a colored highlight in Tab B
- [x] The presence list in the header shows both users with correct colors
- [x] Closing Tab A causes its cursor to disappear from Tab B (after awareness timeout)
- [x] Reloading a tab preserves the same user name and color
- [x] Three or more tabs all see each other's cursors simultaneously

🤖 Generated with [Claude Code](https://claude.com/claude-code)