### PR TITLE
feat(server): implement document CRUD API endpoints

### DIFF
--- a/docs/milestones/persistence-and-document-management/prs/03-document-crud-api/implementation-plan.md
+++ b/docs/milestones/persistence-and-document-management/prs/03-document-crud-api/implementation-plan.md
@@ -2,14 +2,14 @@
 
 ## Prerequisites
 
-- [ ] PR 1 (Database Schema & Migrations) merged
-- [ ] PostgreSQL running with migrations applied
+- [x] PR 1 (Database Schema & Migrations) merged
+- [x] PostgreSQL running with migrations applied
 
 ## Steps
 
 ### Step 1: Update the DocumentSummary response type
 
-- [ ] In `packages/server/src/documents/api.rs`, update `DocumentSummary` to use proper types:
+- [x] In `packages/server/src/documents/api.rs`, update `DocumentSummary` to use proper types:
 
 ```rust
 use chrono::{DateTime, Utc};
@@ -36,7 +36,7 @@ impl From<DocumentRow> for DocumentSummary {
 
 ### Step 2: Implement the list endpoint
 
-- [ ] Replace the `list_documents` stub:
+- [x] Replace the `list_documents` stub:
 
 ```rust
 pub async fn list_documents(
@@ -51,7 +51,7 @@ pub async fn list_documents(
 
 ### Step 3: Implement the create endpoint
 
-- [ ] Replace the `create_document` stub:
+- [x] Replace the `create_document` stub:
 
 ```rust
 pub async fn create_document(
@@ -70,12 +70,12 @@ pub async fn create_document(
 }
 ```
 
-- [ ] Import `StatusCode` from axum
-- [ ] Update the return type in the route to accept the tuple
+- [x] Import `StatusCode` from axum
+- [x] Update the return type in the route to accept the tuple
 
 ### Step 4: Implement the get endpoint
 
-- [ ] Replace the `get_document` stub:
+- [x] Replace the `get_document` stub:
 
 ```rust
 pub async fn get_document(
@@ -92,7 +92,7 @@ pub async fn get_document(
 
 ### Step 5: Implement the delete endpoint
 
-- [ ] Add a `delete_document` handler:
+- [x] Add a `delete_document` handler:
 
 ```rust
 pub async fn delete_document(
@@ -123,7 +123,7 @@ pub async fn delete_document(
 
 ### Step 6: Implement the rename endpoint
 
-- [ ] Add `update_document_title` to `db.rs`:
+- [x] Add `update_document_title` to `db.rs`:
 
 ```rust
 pub async fn update_document_title(&self, id: Uuid, title: &str) -> Result<Option<DocumentRow>, sqlx::Error> {
@@ -138,7 +138,7 @@ pub async fn update_document_title(&self, id: Uuid, title: &str) -> Result<Optio
 }
 ```
 
-- [ ] Add the handler:
+- [x] Add the handler:
 
 ```rust
 #[derive(Deserialize)]
@@ -165,7 +165,7 @@ pub async fn update_document(
 
 ### Step 7: Register routes
 
-- [ ] In `packages/server/src/lib.rs`, add the new routes:
+- [x] In `packages/server/src/lib.rs`, add the new routes:
 
 ```rust
 use axum::routing::{delete, patch};
@@ -176,7 +176,7 @@ use axum::routing::{delete, patch};
 
 ### Step 8: Guard WebSocket connections
 
-- [ ] In `websocket/handler.rs`, verify the document exists before upgrading:
+- [x] In `websocket/handler.rs`, verify the document exists before upgrading:
 
 ```rust
 pub async fn ws_upgrade(
@@ -196,7 +196,7 @@ pub async fn ws_upgrade(
 
 ### Step 9: Tests
 
-- [ ] Write API tests in `packages/server/tests/api.rs`:
+- [x] Write API tests in `packages/server/tests/api.rs`:
 
 ```rust
 #[tokio::test]
@@ -230,15 +230,15 @@ async fn test_websocket_rejects_nonexistent_document() {
 
 ## Verification
 
-- [ ] `curl -X POST localhost:8080/api/docs -H 'Content-Type: application/json' -d '{"title":"Test"}'` → 201 with document JSON
-- [ ] `curl localhost:8080/api/docs` → list includes the created document
-- [ ] `curl localhost:8080/api/docs/{id}` → 200 with document details
-- [ ] `curl -X PATCH localhost:8080/api/docs/{id} -H 'Content-Type: application/json' -d '{"title":"Renamed"}'` → 200 with updated title
-- [ ] `curl -X DELETE localhost:8080/api/docs/{id}` → 204
-- [ ] `curl localhost:8080/api/docs/{id}` → 404 after deletion
-- [ ] WebSocket connection to a nonexistent document ID fails
-- [ ] WebSocket connection to a valid document ID succeeds
-- [ ] `cargo test` passes all new tests
+- [x] `curl -X POST localhost:8080/api/docs -H 'Content-Type: application/json' -d '{"title":"Test"}'` → 201 with document JSON
+- [x] `curl localhost:8080/api/docs` → list includes the created document
+- [x] `curl localhost:8080/api/docs/{id}` → 200 with document details
+- [x] `curl -X PATCH localhost:8080/api/docs/{id} -H 'Content-Type: application/json' -d '{"title":"Renamed"}'` → 200 with updated title
+- [x] `curl -X DELETE localhost:8080/api/docs/{id}` → 204
+- [x] `curl localhost:8080/api/docs/{id}` → 404 after deletion
+- [x] WebSocket connection to a nonexistent document ID fails
+- [x] WebSocket connection to a valid document ID succeeds
+- [x] `cargo test` passes all new tests
 
 ## Files Created/Modified
 

--- a/packages/server/src/db.rs
+++ b/packages/server/src/db.rs
@@ -68,6 +68,21 @@ impl Database {
         Ok(result.rows_affected() > 0)
     }
 
+    pub async fn update_document_title(
+        &self,
+        id: Uuid,
+        title: &str,
+    ) -> Result<Option<DocumentRow>, sqlx::Error> {
+        sqlx::query_as::<_, DocumentRow>(
+            r#"UPDATE documents SET title = $2, updated_at = NOW() WHERE id = $1
+               RETURNING id, title, schema_version, snapshot_key, created_at, updated_at"#,
+        )
+        .bind(id)
+        .bind(title)
+        .fetch_optional(&self.pool)
+        .await
+    }
+
     pub async fn update_document_snapshot(
         &self,
         id: Uuid,

--- a/packages/server/src/documents/api.rs
+++ b/packages/server/src/documents/api.rs
@@ -1,19 +1,32 @@
 use axum::{
     extract::{Path, Query, State},
+    http::StatusCode,
     Json,
 };
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use uuid::Uuid;
 
-use crate::{errors::AppError, AppState};
+use crate::{db::DocumentRow, errors::AppError, AppState};
 
 #[derive(Serialize)]
 pub struct DocumentSummary {
     pub id: Uuid,
     pub title: String,
-    pub created_at: String,
-    pub updated_at: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl From<DocumentRow> for DocumentSummary {
+    fn from(row: DocumentRow) -> Self {
+        Self {
+            id: row.id,
+            title: row.title,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+        }
+    }
 }
 
 #[derive(Deserialize)]
@@ -35,29 +48,108 @@ pub struct PushContentRequest {
     pub content: String,
 }
 
-// --- Handler stubs ---
+#[derive(Deserialize)]
+pub struct UpdateDocumentRequest {
+    pub title: Option<String>,
+}
+
+// --- Handlers ---
 
 pub async fn list_documents(
-    State(_state): State<Arc<AppState>>,
+    State(state): State<Arc<AppState>>,
 ) -> Result<Json<Vec<DocumentSummary>>, AppError> {
-    // TODO: Query database for documents accessible to the authenticated user
-    Ok(Json(vec![]))
+    let rows = state
+        .db
+        .list_documents()
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+    let docs: Vec<DocumentSummary> = rows.into_iter().map(Into::into).collect();
+    Ok(Json(docs))
 }
 
 pub async fn create_document(
-    State(_state): State<Arc<AppState>>,
-    Json(_body): Json<CreateDocumentRequest>,
-) -> Result<Json<DocumentSummary>, AppError> {
-    // TODO: Create document in database, optionally parse initial markdown content
-    Err(AppError::Internal("Not yet implemented".to_string()))
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<CreateDocumentRequest>,
+) -> Result<(StatusCode, Json<DocumentSummary>), AppError> {
+    if body.title.trim().is_empty() {
+        return Err(AppError::BadRequest("Title is required".to_string()));
+    }
+
+    let id = Uuid::new_v4();
+    let row = state
+        .db
+        .create_document(id, body.title.trim())
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    Ok((StatusCode::CREATED, Json(row.into())))
 }
 
 pub async fn get_document(
-    State(_state): State<Arc<AppState>>,
-    Path(_id): Path<Uuid>,
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<Uuid>,
 ) -> Result<Json<DocumentSummary>, AppError> {
-    // TODO: Fetch document metadata
-    Err(AppError::NotFound("Document not found".to_string()))
+    let row = state
+        .db
+        .get_document(id)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+        .ok_or_else(|| AppError::NotFound("Document not found".to_string()))?;
+
+    Ok(Json(row.into()))
+}
+
+pub async fn delete_document(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<Uuid>,
+) -> Result<StatusCode, AppError> {
+    let doc = state
+        .db
+        .get_document(id)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+        .ok_or_else(|| AppError::NotFound("Document not found".to_string()))?;
+
+    // Unload from memory if active
+    state.document_sessions.unload(id);
+
+    // Delete S3 snapshot if exists
+    if doc.snapshot_key.is_some() {
+        state
+            .storage
+            .delete_snapshot(id)
+            .await
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+    }
+
+    // Delete from database (cascades to update_log and permissions)
+    state
+        .db
+        .delete_document(id)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+pub async fn update_document(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<Uuid>,
+    Json(body): Json<UpdateDocumentRequest>,
+) -> Result<Json<DocumentSummary>, AppError> {
+    let title = body
+        .title
+        .filter(|t| !t.trim().is_empty())
+        .ok_or_else(|| AppError::BadRequest("Title is required".to_string()))?;
+
+    let row = state
+        .db
+        .update_document_title(id, title.trim())
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+        .ok_or_else(|| AppError::NotFound("Document not found".to_string()))?;
+
+    Ok(Json(row.into()))
 }
 
 pub async fn get_content(

--- a/packages/server/src/lib.rs
+++ b/packages/server/src/lib.rs
@@ -6,7 +6,7 @@ pub mod sidecar;
 pub mod websocket;
 
 use axum::{
-    routing::{get, post},
+    routing::{delete, get, patch, post},
     Json, Router,
 };
 use serde_json::json;
@@ -34,6 +34,14 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .route("/api/docs", get(documents::api::list_documents))
         .route("/api/docs", post(documents::api::create_document))
         .route("/api/docs/{id}", get(documents::api::get_document))
+        .route(
+            "/api/docs/{id}",
+            delete(documents::api::delete_document),
+        )
+        .route(
+            "/api/docs/{id}",
+            patch(documents::api::update_document),
+        )
         .route("/api/docs/{id}/content", get(documents::api::get_content))
         .route(
             "/api/docs/{id}/content",

--- a/packages/server/src/websocket/handler.rs
+++ b/packages/server/src/websocket/handler.rs
@@ -26,6 +26,9 @@ pub async fn ws_upgrade(
     Path(doc_id): Path<Uuid>,
     State(state): State<Arc<AppState>>,
 ) -> Result<impl IntoResponse, AppError> {
+    // get_or_load checks the in-memory cache first, then falls back to
+    // loading from the database + S3. If the document doesn't exist in either
+    // place, it returns a 404.
     let session = state
         .document_sessions
         .get_or_load(doc_id, &state.db, &state.storage)

--- a/packages/server/tests/api_test.rs
+++ b/packages/server/tests/api_test.rs
@@ -1,0 +1,308 @@
+//! Integration tests for the Document CRUD API.
+//!
+//! These tests require:
+//! - PostgreSQL with migrations applied (DATABASE_URL)
+//! - LocalStack S3 running (S3_ENDPOINT=http://localhost:4566)
+//!
+//! Run with: cargo test --test api_test
+//! Skip with: set SKIP_PERSISTENCE_TESTS=1
+
+use cadmus_server::db::Database;
+use cadmus_server::documents::storage::SnapshotStorage;
+use cadmus_server::{build_router, AppState};
+use std::sync::Arc;
+use tokio::net::TcpListener;
+
+/// Check if persistence tests should be skipped (no infrastructure available).
+fn should_skip() -> bool {
+    std::env::var("SKIP_PERSISTENCE_TESTS").is_ok()
+}
+
+fn database_url() -> String {
+    std::env::var("DATABASE_URL").unwrap_or_else(|_| "postgres://localhost/cadmus_test".to_string())
+}
+
+fn s3_endpoint() -> String {
+    std::env::var("S3_ENDPOINT").unwrap_or_else(|_| "http://localhost:4566".to_string())
+}
+
+const S3_BUCKET: &str = "cadmus-documents";
+
+async fn spawn_test_server() -> Option<String> {
+    if should_skip() {
+        return None;
+    }
+
+    let db = match Database::connect(&database_url()).await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping API test — cannot connect to database: {e}");
+            return None;
+        }
+    };
+
+    // Run migrations
+    if let Err(e) = sqlx::migrate!().run(&db.pool).await {
+        eprintln!("Skipping API test — migration failed: {e}");
+        return None;
+    }
+
+    let storage = SnapshotStorage::new(S3_BUCKET, Some(&s3_endpoint())).await;
+
+    let state = Arc::new(AppState {
+        db,
+        document_sessions: Arc::new(cadmus_server::documents::SessionManager::new()),
+        storage,
+        sidecar: cadmus_server::sidecar::SidecarClient::new("http://localhost:3001"),
+        config: cadmus_server::config::Config {
+            database_url: database_url(),
+            sidecar_url: "http://localhost:3001".to_string(),
+            jwt_secret: "test-secret".to_string(),
+            s3_bucket: S3_BUCKET.to_string(),
+            s3_endpoint: Some(s3_endpoint()),
+            port: 0,
+        },
+    });
+
+    let app = build_router(state);
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    Some(format!("http://127.0.0.1:{}", addr.port()))
+}
+
+#[tokio::test]
+async fn test_create_and_list_documents() {
+    let Some(base_url) = spawn_test_server().await else {
+        return;
+    };
+
+    let client = reqwest::Client::new();
+
+    // Create a document
+    let resp = client
+        .post(format!("{base_url}/api/docs"))
+        .json(&serde_json::json!({ "title": "Test Doc" }))
+        .send()
+        .await
+        .expect("create request failed");
+
+    assert_eq!(resp.status(), 201);
+    let doc: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(doc["title"], "Test Doc");
+    let doc_id = doc["id"].as_str().unwrap();
+    assert!(!doc_id.is_empty());
+    assert!(doc["created_at"].is_string());
+    assert!(doc["updated_at"].is_string());
+
+    // List documents — should include the created one
+    let resp = client
+        .get(format!("{base_url}/api/docs"))
+        .send()
+        .await
+        .expect("list request failed");
+
+    assert_eq!(resp.status(), 200);
+    let docs: Vec<serde_json::Value> = resp.json().await.unwrap();
+    assert!(
+        docs.iter().any(|d| d["id"].as_str() == Some(doc_id)),
+        "created document should appear in list"
+    );
+
+    // Cleanup
+    client
+        .delete(format!("{base_url}/api/docs/{doc_id}"))
+        .send()
+        .await
+        .ok();
+}
+
+#[tokio::test]
+async fn test_create_document_rejects_empty_title() {
+    let Some(base_url) = spawn_test_server().await else {
+        return;
+    };
+
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .post(format!("{base_url}/api/docs"))
+        .json(&serde_json::json!({ "title": "   " }))
+        .send()
+        .await
+        .expect("create request failed");
+
+    assert_eq!(resp.status(), 400);
+}
+
+#[tokio::test]
+async fn test_get_document() {
+    let Some(base_url) = spawn_test_server().await else {
+        return;
+    };
+
+    let client = reqwest::Client::new();
+
+    // Create a doc
+    let resp = client
+        .post(format!("{base_url}/api/docs"))
+        .json(&serde_json::json!({ "title": "Get Test" }))
+        .send()
+        .await
+        .unwrap();
+    let doc: serde_json::Value = resp.json().await.unwrap();
+    let doc_id = doc["id"].as_str().unwrap();
+
+    // Get it
+    let resp = client
+        .get(format!("{base_url}/api/docs/{doc_id}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let fetched: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(fetched["title"], "Get Test");
+    assert_eq!(fetched["id"].as_str(), Some(doc_id));
+
+    // Get nonexistent
+    let resp = client
+        .get(format!(
+            "{base_url}/api/docs/00000000-0000-0000-0000-000000000000"
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 404);
+
+    // Cleanup
+    client
+        .delete(format!("{base_url}/api/docs/{doc_id}"))
+        .send()
+        .await
+        .ok();
+}
+
+#[tokio::test]
+async fn test_delete_document() {
+    let Some(base_url) = spawn_test_server().await else {
+        return;
+    };
+
+    let client = reqwest::Client::new();
+
+    // Create a doc
+    let resp = client
+        .post(format!("{base_url}/api/docs"))
+        .json(&serde_json::json!({ "title": "Delete Test" }))
+        .send()
+        .await
+        .unwrap();
+    let doc: serde_json::Value = resp.json().await.unwrap();
+    let doc_id = doc["id"].as_str().unwrap();
+
+    // Delete it
+    let resp = client
+        .delete(format!("{base_url}/api/docs/{doc_id}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 204);
+
+    // Verify it's gone
+    let resp = client
+        .get(format!("{base_url}/api/docs/{doc_id}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 404);
+
+    // Delete nonexistent → 404
+    let resp = client
+        .delete(format!("{base_url}/api/docs/{doc_id}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 404);
+}
+
+#[tokio::test]
+async fn test_update_document_title() {
+    let Some(base_url) = spawn_test_server().await else {
+        return;
+    };
+
+    let client = reqwest::Client::new();
+
+    // Create a doc
+    let resp = client
+        .post(format!("{base_url}/api/docs"))
+        .json(&serde_json::json!({ "title": "Original Title" }))
+        .send()
+        .await
+        .unwrap();
+    let doc: serde_json::Value = resp.json().await.unwrap();
+    let doc_id = doc["id"].as_str().unwrap();
+
+    // Rename it
+    let resp = client
+        .patch(format!("{base_url}/api/docs/{doc_id}"))
+        .json(&serde_json::json!({ "title": "Renamed Title" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let updated: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(updated["title"], "Renamed Title");
+    assert_eq!(updated["id"].as_str(), Some(doc_id));
+
+    // Rename with empty title → 400
+    let resp = client
+        .patch(format!("{base_url}/api/docs/{doc_id}"))
+        .json(&serde_json::json!({ "title": "" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+
+    // Rename nonexistent → 404
+    let resp = client
+        .patch(format!(
+            "{base_url}/api/docs/00000000-0000-0000-0000-000000000000"
+        ))
+        .json(&serde_json::json!({ "title": "Nope" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 404);
+
+    // Cleanup
+    client
+        .delete(format!("{base_url}/api/docs/{doc_id}"))
+        .send()
+        .await
+        .ok();
+}
+
+#[tokio::test]
+async fn test_websocket_rejects_nonexistent_document() {
+    let Some(base_url) = spawn_test_server().await else {
+        return;
+    };
+
+    // Attempt WebSocket upgrade for a document that doesn't exist in the DB
+    let ws_url = format!(
+        "{}/api/docs/00000000-0000-0000-0000-000000000000/ws",
+        base_url.replace("http://", "ws://")
+    );
+
+    let result = tokio_tungstenite::connect_async(&ws_url).await;
+    assert!(
+        result.is_err(),
+        "WebSocket upgrade should fail for nonexistent document"
+    );
+}


### PR DESCRIPTION
## Summary
- Replace all document handler stubs with real database-backed implementations: list, create (201), get, delete (204), and rename/update (PATCH)
- Add `update_document_title` method to the database layer with `RETURNING` clause
- Register `DELETE` and `PATCH` routes for `/api/docs/{id}`
- Add 6 integration tests covering all CRUD operations, validation errors, and WebSocket rejection for nonexistent documents

## Test plan
- [x] `cargo build` compiles cleanly
- [x] `cargo test` — all 13 tests pass (6 new API + 3 persistence + 4 WebSocket)
- [x] `pnpm run format:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)