### PR TITLE
feat(server): add users table and auth endpoints

### DIFF
--- a/docs/milestones/auth-and-permissions/prs/01-users-and-auth-endpoints/implementation-plan.md
+++ b/docs/milestones/auth-and-permissions/prs/01-users-and-auth-endpoints/implementation-plan.md
@@ -3,20 +3,20 @@
 ## Prerequisites
 
 - [x] Milestone 2 merged and working
-- [ ] PostgreSQL running with M2 migrations applied
-- [ ] `argon2` crate available on crates.io
+- [x] PostgreSQL running with M2 migrations applied
+- [x] `argon2` crate available on crates.io
 
 ## Steps
 
 ### Step 1: Add new dependencies to Cargo.toml
 
-- [ ] Add `argon2 = "0.5"` to `packages/server/Cargo.toml`
-- [ ] Add `rand = "0.8"` if not already a transitive dependency (needed for salt generation)
-- [ ] Verify `jsonwebtoken = "9"` is already present (it is)
+- [x] Add `argon2 = "0.5"` to `packages/server/Cargo.toml`
+- [x] Add `rand = "0.8"` if not already a transitive dependency (needed for salt generation)
+- [x] Verify `jsonwebtoken = "9"` is already present (it is)
 
 ### Step 2: Create the users migration
 
-- [ ] Create `packages/server/migrations/20260312000002_users.sql`:
+- [x] Create `packages/server/migrations/20260312000002_users.sql`:
 
 ```sql
 -- Users table
@@ -42,7 +42,7 @@ ALTER TABLE document_permissions
 
 ### Step 3: Add user database methods
 
-- [ ] Add `UserRow` struct to `packages/server/src/db.rs`:
+- [x] Add `UserRow` struct to `packages/server/src/db.rs`:
 
 ```rust
 #[derive(Debug, sqlx::FromRow)]
@@ -56,7 +56,7 @@ pub struct UserRow {
 }
 ```
 
-- [ ] Add user query methods to `Database`:
+- [x] Add user query methods to `Database`:
 
 ```rust
 pub async fn create_user(&self, id: Uuid, email: &str, display_name: &str, password_hash: &str) -> Result<UserRow, sqlx::Error>;
@@ -64,12 +64,12 @@ pub async fn get_user_by_id(&self, id: Uuid) -> Result<Option<UserRow>, sqlx::Er
 pub async fn get_user_by_email(&self, email: &str) -> Result<Option<UserRow>, sqlx::Error>;
 ```
 
-- [ ] Update `create_document` to accept an optional `created_by: Option<Uuid>` parameter
+- [x] Update `create_document` to accept an optional `created_by: Option<Uuid>` parameter
 
 ### Step 4: Create the password hashing module
 
-- [ ] Create `packages/server/src/auth/mod.rs` with `pub mod password; pub mod jwt; pub mod handlers;`
-- [ ] Create `packages/server/src/auth/password.rs`:
+- [x] Create `packages/server/src/auth/mod.rs` with `pub mod password; pub mod jwt; pub mod handlers;`
+- [x] Create `packages/server/src/auth/password.rs`:
 
 ```rust
 use argon2::{Argon2, PasswordHash, PasswordHasher, PasswordVerifier};
@@ -96,7 +96,7 @@ pub fn verify_password(password: &str, hash: &str) -> Result<bool, AppError> {
 
 ### Step 5: Create the JWT module
 
-- [ ] Create `packages/server/src/auth/jwt.rs`:
+- [x] Create `packages/server/src/auth/jwt.rs`:
 
 ```rust
 use chrono::Utc;
@@ -127,12 +127,12 @@ pub fn create_ws_token(user_id: Uuid, secret: &str) -> Result<String, AppError>;
 pub fn validate_token(token: &str, expected_type: &str, secret: &str) -> Result<Claims, AppError>;
 ```
 
-- [ ] Implement all four functions using `jsonwebtoken::encode` / `decode`
-- [ ] `validate_token` checks both signature validity and the `type` claim
+- [x] Implement all four functions using `jsonwebtoken::encode` / `decode`
+- [x] `validate_token` checks both signature validity and the `type` claim
 
 ### Step 6: Create auth request/response types
 
-- [ ] In `packages/server/src/auth/handlers.rs`, define:
+- [x] In `packages/server/src/auth/handlers.rs`, define:
 
 ```rust
 #[derive(Deserialize)]
@@ -183,7 +183,7 @@ pub struct WsTokenResponse {
 
 ### Step 7: Implement auth handlers
 
-- [ ] Implement `register` handler:
+- [x] Implement `register` handler:
   - Validate email (contains `@`, trim, lowercase), display_name (non-empty), password (≥8 chars)
   - Check for existing user with same email → 409 Conflict
   - Hash password with `auth::password::hash_password`
@@ -191,31 +191,31 @@ pub struct WsTokenResponse {
   - Issue access + refresh tokens
   - Return `AuthResponse` with 201 status
 
-- [ ] Implement `login` handler:
+- [x] Implement `login` handler:
   - Look up user by email (lowercased, trimmed)
   - If not found → 401 "Invalid email or password"
   - Verify password → if mismatch, 401 "Invalid email or password"
   - Issue access + refresh tokens
   - Return `AuthResponse`
 
-- [ ] Implement `refresh` handler:
+- [x] Implement `refresh` handler:
   - Validate refresh token (type must be "refresh")
   - Look up user by ID from claims (ensures user still exists)
   - Issue new access token only (refresh token stays the same)
   - Return `TokenResponse`
 
-- [ ] Implement `ws_token` handler:
+- [x] Implement `ws_token` handler:
   - This handler requires an access token (will be enforced via extractor in PR 2; for now, manually parse the Authorization header)
   - Issue a ws-token for the authenticated user
   - Return `WsTokenResponse`
 
-- [ ] Implement `me` handler:
+- [x] Implement `me` handler:
   - Parse access token from Authorization header
   - Look up user, return `UserProfile`
 
 ### Step 8: Register auth routes
 
-- [ ] In `packages/server/src/lib.rs`:
+- [x] In `packages/server/src/lib.rs`:
   - Add `pub mod auth;`
   - Add routes:
 
@@ -229,18 +229,18 @@ pub struct WsTokenResponse {
 
 ### Step 9: Tests
 
-- [ ] Write unit tests for password hashing in `auth/password.rs`:
+- [x] Write unit tests for password hashing in `auth/password.rs`:
   - Hash and verify a valid password
   - Verify returns false for wrong password
   - Hash produces different output for same input (salt is random)
 
-- [ ] Write unit tests for JWT in `auth/jwt.rs`:
+- [x] Write unit tests for JWT in `auth/jwt.rs`:
   - Create and validate an access token
   - Create and validate a refresh token
   - Reject an expired token
   - Reject a token with wrong type (use refresh token as access)
 
-- [ ] Write integration tests in `packages/server/tests/auth.rs`:
+- [x] Write integration tests in `packages/server/tests/auth_test.rs`:
   - Register a new user → 201 with valid tokens
   - Register with duplicate email → 409
   - Register with invalid fields (missing email, short password) → 400
@@ -254,16 +254,16 @@ pub struct WsTokenResponse {
 
 ## Verification
 
-- [ ] `cargo build` succeeds with new dependencies
-- [ ] `sqlx migrate run` applies the users migration
-- [ ] `psql` shows `users` table with correct columns
-- [ ] `psql` shows FK constraint on `document_permissions.user_id`
-- [ ] `psql` shows `created_by` column on `documents` table
-- [ ] Registration creates a user in the database with a hashed password
-- [ ] Login returns valid JWTs
-- [ ] Refresh extends session without re-authentication
-- [ ] `cargo test` passes all new and existing tests
-- [ ] Existing document endpoints still work (no auth enforced yet)
+- [x] `cargo build` succeeds with new dependencies
+- [x] `sqlx migrate run` applies the users migration
+- [x] `psql` shows `users` table with correct columns
+- [x] `psql` shows FK constraint on `document_permissions.user_id`
+- [x] `psql` shows `created_by` column on `documents` table
+- [x] Registration creates a user in the database with a hashed password
+- [x] Login returns valid JWTs
+- [x] Refresh extends session without re-authentication
+- [x] `cargo test` passes all new and existing tests
+- [x] Existing document endpoints still work (no auth enforced yet)
 
 ## Files Created/Modified
 
@@ -275,4 +275,4 @@ pub struct WsTokenResponse {
 - `packages/server/src/auth/handlers.rs` (new)
 - `packages/server/src/db.rs` (modified — add UserRow, user queries, update create_document)
 - `packages/server/src/lib.rs` (modified — add auth module, auth routes)
-- `packages/server/tests/auth.rs` (new)
+- `packages/server/tests/auth_test.rs` (new)

--- a/packages/server/Cargo.lock
+++ b/packages/server/Cargo.lock
@@ -42,6 +42,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
+]
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -631,6 +643,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,6 +692,7 @@ dependencies = [
 name = "cadmus-server"
 version = "0.1.0"
 dependencies = [
+ "argon2",
  "aws-config",
  "aws-sdk-s3",
  "axum",
@@ -678,6 +700,7 @@ dependencies = [
  "dashmap",
  "futures-util",
  "jsonwebtoken",
+ "rand 0.8.5",
  "reqwest",
  "serde",
  "serde_json",
@@ -2073,6 +2096,17 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]

--- a/packages/server/Cargo.toml
+++ b/packages/server/Cargo.toml
@@ -21,6 +21,8 @@ serde_json = "1"
 
 # Auth
 jsonwebtoken = "9"
+argon2 = "0.5"
+rand = "0.8"
 
 # Database
 sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "uuid", "chrono", "migrate"] }

--- a/packages/server/migrations/20260312000002_users.sql
+++ b/packages/server/migrations/20260312000002_users.sql
@@ -1,0 +1,19 @@
+-- Users table
+CREATE TABLE users (
+    id              UUID PRIMARY KEY,
+    email           TEXT NOT NULL UNIQUE,
+    display_name    TEXT NOT NULL,
+    password_hash   TEXT NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_users_email ON users(email);
+
+-- Add owner tracking to documents
+ALTER TABLE documents ADD COLUMN created_by UUID REFERENCES users(id);
+
+-- Add FK constraint to document_permissions (column exists but had no FK)
+ALTER TABLE document_permissions
+    ADD CONSTRAINT fk_document_permissions_user_id
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE;

--- a/packages/server/src/auth/handlers.rs
+++ b/packages/server/src/auth/handlers.rs
@@ -1,0 +1,242 @@
+use axum::extract::State;
+use axum::http::{HeaderMap, StatusCode};
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::auth::{jwt, password};
+use crate::errors::AppError;
+use crate::AppState;
+
+// ── Request types ──
+
+#[derive(Deserialize)]
+pub struct RegisterRequest {
+    pub email: String,
+    pub display_name: String,
+    pub password: String,
+}
+
+#[derive(Deserialize)]
+pub struct LoginRequest {
+    pub email: String,
+    pub password: String,
+}
+
+#[derive(Deserialize)]
+pub struct RefreshRequest {
+    pub refresh_token: String,
+}
+
+// ── Response types ──
+
+#[derive(Serialize)]
+pub struct AuthResponse {
+    pub user: UserProfile,
+    pub access_token: String,
+    pub refresh_token: String,
+    pub expires_in: u64,
+}
+
+#[derive(Serialize)]
+pub struct UserProfile {
+    pub id: Uuid,
+    pub email: String,
+    pub display_name: String,
+}
+
+#[derive(Serialize)]
+pub struct TokenResponse {
+    pub access_token: String,
+    pub expires_in: u64,
+}
+
+#[derive(Serialize)]
+pub struct WsTokenResponse {
+    pub ws_token: String,
+    pub expires_in: u64,
+}
+
+// ── Helpers ──
+
+fn extract_bearer_token(headers: &HeaderMap) -> Result<&str, AppError> {
+    let header = headers
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .ok_or_else(|| AppError::Unauthorized("Missing authorization header".to_string()))?;
+
+    header
+        .strip_prefix("Bearer ")
+        .ok_or_else(|| AppError::Unauthorized("Invalid authorization header".to_string()))
+}
+
+// ── Handlers ──
+
+pub async fn register(
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<RegisterRequest>,
+) -> Result<(StatusCode, Json<AuthResponse>), AppError> {
+    // Validate
+    let email = body.email.trim().to_lowercase();
+    if email.is_empty() || !email.contains('@') {
+        return Err(AppError::BadRequest("Invalid email address".to_string()));
+    }
+
+    let display_name = body.display_name.trim().to_string();
+    if display_name.is_empty() || display_name.len() > 100 {
+        return Err(AppError::BadRequest(
+            "Display name must be between 1 and 100 characters".to_string(),
+        ));
+    }
+
+    if body.password.len() < 8 {
+        return Err(AppError::BadRequest(
+            "Password must be at least 8 characters".to_string(),
+        ));
+    }
+
+    // Check for existing user
+    if state.db.get_user_by_email(&email).await.map_err(|e| AppError::Internal(e.to_string()))?.is_some() {
+        return Err(AppError::Conflict("Email already registered".to_string()));
+    }
+
+    // Hash password
+    let password_hash = password::hash_password(&body.password)?;
+
+    // Create user
+    let id = Uuid::new_v4();
+    let user = state
+        .db
+        .create_user(id, &email, &display_name, &password_hash)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    // Issue tokens
+    let access_token =
+        jwt::create_access_token(user.id, &user.email, &user.display_name, &state.config.jwt_secret)?;
+    let refresh_token = jwt::create_refresh_token(user.id, &state.config.jwt_secret)?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(AuthResponse {
+            user: UserProfile {
+                id: user.id,
+                email: user.email,
+                display_name: user.display_name,
+            },
+            access_token,
+            refresh_token,
+            expires_in: 900,
+        }),
+    ))
+}
+
+pub async fn login(
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<LoginRequest>,
+) -> Result<Json<AuthResponse>, AppError> {
+    let email = body.email.trim().to_lowercase();
+
+    let user = state
+        .db
+        .get_user_by_email(&email)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+        .ok_or_else(|| AppError::Unauthorized("Invalid email or password".to_string()))?;
+
+    if !password::verify_password(&body.password, &user.password_hash)? {
+        return Err(AppError::Unauthorized(
+            "Invalid email or password".to_string(),
+        ));
+    }
+
+    let access_token =
+        jwt::create_access_token(user.id, &user.email, &user.display_name, &state.config.jwt_secret)?;
+    let refresh_token = jwt::create_refresh_token(user.id, &state.config.jwt_secret)?;
+
+    Ok(Json(AuthResponse {
+        user: UserProfile {
+            id: user.id,
+            email: user.email,
+            display_name: user.display_name,
+        },
+        access_token,
+        refresh_token,
+        expires_in: 900,
+    }))
+}
+
+pub async fn refresh(
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<RefreshRequest>,
+) -> Result<Json<TokenResponse>, AppError> {
+    let claims = jwt::validate_token(&body.refresh_token, "refresh", &state.config.jwt_secret)?;
+
+    let user_id: Uuid = claims
+        .sub
+        .parse()
+        .map_err(|_| AppError::Unauthorized("Invalid or expired token".to_string()))?;
+
+    // Ensure user still exists
+    let user = state
+        .db
+        .get_user_by_id(user_id)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+        .ok_or_else(|| AppError::Unauthorized("Invalid or expired token".to_string()))?;
+
+    let access_token =
+        jwt::create_access_token(user.id, &user.email, &user.display_name, &state.config.jwt_secret)?;
+
+    Ok(Json(TokenResponse {
+        access_token,
+        expires_in: 900,
+    }))
+}
+
+pub async fn ws_token(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<Json<WsTokenResponse>, AppError> {
+    let token = extract_bearer_token(&headers)?;
+    let claims = jwt::validate_token(token, "access", &state.config.jwt_secret)?;
+
+    let user_id: Uuid = claims
+        .sub
+        .parse()
+        .map_err(|_| AppError::Unauthorized("Invalid or expired token".to_string()))?;
+
+    let ws_token = jwt::create_ws_token(user_id, &state.config.jwt_secret)?;
+
+    Ok(Json(WsTokenResponse {
+        ws_token,
+        expires_in: 30,
+    }))
+}
+
+pub async fn me(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<Json<UserProfile>, AppError> {
+    let token = extract_bearer_token(&headers)?;
+    let claims = jwt::validate_token(token, "access", &state.config.jwt_secret)?;
+
+    let user_id: Uuid = claims
+        .sub
+        .parse()
+        .map_err(|_| AppError::Unauthorized("Invalid or expired token".to_string()))?;
+
+    let user = state
+        .db
+        .get_user_by_id(user_id)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+        .ok_or_else(|| AppError::Unauthorized("Invalid or expired token".to_string()))?;
+
+    Ok(Json(UserProfile {
+        id: user.id,
+        email: user.email,
+        display_name: user.display_name,
+    }))
+}

--- a/packages/server/src/auth/jwt.rs
+++ b/packages/server/src/auth/jwt.rs
@@ -1,0 +1,163 @@
+use chrono::Utc;
+use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::errors::AppError;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Claims {
+    pub sub: String,
+    pub email: Option<String>,
+    pub name: Option<String>,
+    #[serde(rename = "type")]
+    pub token_type: String,
+    pub iat: i64,
+    pub exp: i64,
+}
+
+const ACCESS_TOKEN_EXPIRY_SECS: i64 = 900; // 15 minutes
+const REFRESH_TOKEN_EXPIRY_SECS: i64 = 604800; // 7 days
+const WS_TOKEN_EXPIRY_SECS: i64 = 30; // 30 seconds
+
+pub fn create_access_token(
+    user_id: Uuid,
+    email: &str,
+    name: &str,
+    secret: &str,
+) -> Result<String, AppError> {
+    let now = Utc::now().timestamp();
+    let claims = Claims {
+        sub: user_id.to_string(),
+        email: Some(email.to_string()),
+        name: Some(name.to_string()),
+        token_type: "access".to_string(),
+        iat: now,
+        exp: now + ACCESS_TOKEN_EXPIRY_SECS,
+    };
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(secret.as_bytes()),
+    )
+    .map_err(|e| AppError::Internal(format!("Token creation failed: {}", e)))
+}
+
+pub fn create_refresh_token(user_id: Uuid, secret: &str) -> Result<String, AppError> {
+    let now = Utc::now().timestamp();
+    let claims = Claims {
+        sub: user_id.to_string(),
+        email: None,
+        name: None,
+        token_type: "refresh".to_string(),
+        iat: now,
+        exp: now + REFRESH_TOKEN_EXPIRY_SECS,
+    };
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(secret.as_bytes()),
+    )
+    .map_err(|e| AppError::Internal(format!("Token creation failed: {}", e)))
+}
+
+pub fn create_ws_token(user_id: Uuid, secret: &str) -> Result<String, AppError> {
+    let now = Utc::now().timestamp();
+    let claims = Claims {
+        sub: user_id.to_string(),
+        email: None,
+        name: None,
+        token_type: "ws".to_string(),
+        iat: now,
+        exp: now + WS_TOKEN_EXPIRY_SECS,
+    };
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(secret.as_bytes()),
+    )
+    .map_err(|e| AppError::Internal(format!("Token creation failed: {}", e)))
+}
+
+pub fn validate_token(
+    token: &str,
+    expected_type: &str,
+    secret: &str,
+) -> Result<Claims, AppError> {
+    let token_data = decode::<Claims>(
+        token,
+        &DecodingKey::from_secret(secret.as_bytes()),
+        &Validation::default(),
+    )
+    .map_err(|_| AppError::Unauthorized("Invalid or expired token".to_string()))?;
+
+    if token_data.claims.token_type != expected_type {
+        return Err(AppError::Unauthorized(
+            "Invalid or expired token".to_string(),
+        ));
+    }
+
+    Ok(token_data.claims)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_SECRET: &str = "test-secret-key";
+
+    #[test]
+    fn test_create_and_validate_access_token() {
+        let user_id = Uuid::new_v4();
+        let token =
+            create_access_token(user_id, "alice@example.com", "Alice", TEST_SECRET).unwrap();
+        let claims = validate_token(&token, "access", TEST_SECRET).unwrap();
+        assert_eq!(claims.sub, user_id.to_string());
+        assert_eq!(claims.email.as_deref(), Some("alice@example.com"));
+        assert_eq!(claims.name.as_deref(), Some("Alice"));
+        assert_eq!(claims.token_type, "access");
+    }
+
+    #[test]
+    fn test_create_and_validate_refresh_token() {
+        let user_id = Uuid::new_v4();
+        let token = create_refresh_token(user_id, TEST_SECRET).unwrap();
+        let claims = validate_token(&token, "refresh", TEST_SECRET).unwrap();
+        assert_eq!(claims.sub, user_id.to_string());
+        assert!(claims.email.is_none());
+        assert!(claims.name.is_none());
+        assert_eq!(claims.token_type, "refresh");
+    }
+
+    #[test]
+    fn test_reject_expired_token() {
+        // Create a token that's already expired by manually building claims
+        let user_id = Uuid::new_v4();
+        let now = Utc::now().timestamp();
+        let claims = Claims {
+            sub: user_id.to_string(),
+            email: None,
+            name: None,
+            token_type: "access".to_string(),
+            iat: now - 1000,
+            exp: now - 500, // expired 500 seconds ago
+        };
+        let token = encode(
+            &Header::default(),
+            &claims,
+            &EncodingKey::from_secret(TEST_SECRET.as_bytes()),
+        )
+        .unwrap();
+        let result = validate_token(&token, "access", TEST_SECRET);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_reject_wrong_token_type() {
+        let user_id = Uuid::new_v4();
+        let token = create_refresh_token(user_id, TEST_SECRET).unwrap();
+        // Try to validate as access token
+        let result = validate_token(&token, "access", TEST_SECRET);
+        assert!(result.is_err());
+    }
+}

--- a/packages/server/src/auth/mod.rs
+++ b/packages/server/src/auth/mod.rs
@@ -1,0 +1,3 @@
+pub mod handlers;
+pub mod jwt;
+pub mod password;

--- a/packages/server/src/auth/password.rs
+++ b/packages/server/src/auth/password.rs
@@ -1,0 +1,51 @@
+use argon2::password_hash::SaltString;
+use argon2::{Argon2, PasswordHash, PasswordHasher, PasswordVerifier};
+use rand::rngs::OsRng;
+
+use crate::errors::AppError;
+
+pub fn hash_password(password: &str) -> Result<String, AppError> {
+    let salt = SaltString::generate(&mut OsRng);
+    let argon2 = Argon2::default();
+    let hash = argon2
+        .hash_password(password.as_bytes(), &salt)
+        .map_err(|e| AppError::Internal(format!("Password hashing failed: {}", e)))?;
+    Ok(hash.to_string())
+}
+
+pub fn verify_password(password: &str, hash: &str) -> Result<bool, AppError> {
+    let parsed_hash = PasswordHash::new(hash)
+        .map_err(|e| AppError::Internal(format!("Invalid password hash: {}", e)))?;
+    Ok(Argon2::default()
+        .verify_password(password.as_bytes(), &parsed_hash)
+        .is_ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hash_and_verify_valid_password() {
+        let password = "securepassword123";
+        let hash = hash_password(password).unwrap();
+        assert!(verify_password(password, &hash).unwrap());
+    }
+
+    #[test]
+    fn test_verify_returns_false_for_wrong_password() {
+        let hash = hash_password("correct-password").unwrap();
+        assert!(!verify_password("wrong-password", &hash).unwrap());
+    }
+
+    #[test]
+    fn test_hash_produces_different_output_for_same_input() {
+        let password = "same-password";
+        let hash1 = hash_password(password).unwrap();
+        let hash2 = hash_password(password).unwrap();
+        assert_ne!(hash1, hash2, "Hashes should differ due to random salt");
+        // Both should still verify
+        assert!(verify_password(password, &hash1).unwrap());
+        assert!(verify_password(password, &hash2).unwrap());
+    }
+}

--- a/packages/server/src/db.rs
+++ b/packages/server/src/db.rs
@@ -19,6 +19,17 @@ pub struct DocumentRow {
     pub updated_at: DateTime<Utc>,
 }
 
+/// A row from the `users` table.
+#[derive(Debug, sqlx::FromRow)]
+pub struct UserRow {
+    pub id: Uuid,
+    pub email: String,
+    pub display_name: String,
+    pub password_hash: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
 impl Database {
     pub async fn connect(url: &str) -> Result<Self, sqlx::Error> {
         let pool = PgPool::connect(url).await?;
@@ -32,13 +43,61 @@ impl Database {
         Ok(Self { pool })
     }
 
-    pub async fn create_document(&self, id: Uuid, title: &str) -> Result<DocumentRow, sqlx::Error> {
+    // ── User queries ──
+
+    pub async fn create_user(
+        &self,
+        id: Uuid,
+        email: &str,
+        display_name: &str,
+        password_hash: &str,
+    ) -> Result<UserRow, sqlx::Error> {
+        sqlx::query_as::<_, UserRow>(
+            r#"INSERT INTO users (id, email, display_name, password_hash)
+               VALUES ($1, $2, $3, $4)
+               RETURNING id, email, display_name, password_hash, created_at, updated_at"#,
+        )
+        .bind(id)
+        .bind(email)
+        .bind(display_name)
+        .bind(password_hash)
+        .fetch_one(&self.pool)
+        .await
+    }
+
+    pub async fn get_user_by_id(&self, id: Uuid) -> Result<Option<UserRow>, sqlx::Error> {
+        sqlx::query_as::<_, UserRow>(
+            "SELECT id, email, display_name, password_hash, created_at, updated_at FROM users WHERE id = $1",
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await
+    }
+
+    pub async fn get_user_by_email(&self, email: &str) -> Result<Option<UserRow>, sqlx::Error> {
+        sqlx::query_as::<_, UserRow>(
+            "SELECT id, email, display_name, password_hash, created_at, updated_at FROM users WHERE email = $1",
+        )
+        .bind(email)
+        .fetch_optional(&self.pool)
+        .await
+    }
+
+    // ── Document queries ──
+
+    pub async fn create_document(
+        &self,
+        id: Uuid,
+        title: &str,
+        created_by: Option<Uuid>,
+    ) -> Result<DocumentRow, sqlx::Error> {
         sqlx::query_as::<_, DocumentRow>(
-            r#"INSERT INTO documents (id, title) VALUES ($1, $2)
+            r#"INSERT INTO documents (id, title, created_by) VALUES ($1, $2, $3)
                RETURNING id, title, schema_version, snapshot_key, created_at, updated_at"#,
         )
         .bind(id)
         .bind(title)
+        .bind(created_by)
         .fetch_one(&self.pool)
         .await
     }

--- a/packages/server/src/documents/api.rs
+++ b/packages/server/src/documents/api.rs
@@ -78,7 +78,7 @@ pub async fn create_document(
     let id = Uuid::new_v4();
     let row = state
         .db
-        .create_document(id, body.title.trim())
+        .create_document(id, body.title.trim(), None)
         .await
         .map_err(|e| AppError::Internal(e.to_string()))?;
 

--- a/packages/server/src/lib.rs
+++ b/packages/server/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod auth;
 pub mod config;
 pub mod db;
 pub mod documents;
@@ -58,7 +59,13 @@ pub fn build_router(state: Arc<AppState>) -> Router {
             "/api/docs/{id}/comments",
             post(documents::api::create_comment),
         )
-        // TODO: Auth endpoints, history endpoints, token management
+        // Auth endpoints
+        .route("/api/auth/register", post(auth::handlers::register))
+        .route("/api/auth/login", post(auth::handlers::login))
+        .route("/api/auth/refresh", post(auth::handlers::refresh))
+        .route("/api/auth/ws-token", post(auth::handlers::ws_token))
+        .route("/api/auth/me", get(auth::handlers::me))
+        // TODO: history endpoints, token management
         .layer(CorsLayer::permissive())
         .layer(TraceLayer::new_for_http())
         .with_state(state)

--- a/packages/server/tests/auth_test.rs
+++ b/packages/server/tests/auth_test.rs
@@ -1,0 +1,385 @@
+//! Integration tests for the Auth API.
+//!
+//! These tests require:
+//! - PostgreSQL with migrations applied (DATABASE_URL)
+//! - LocalStack S3 running (S3_ENDPOINT=http://localhost:4566)
+//!
+//! Run with: cargo test --test auth_test
+//! Skip with: set SKIP_PERSISTENCE_TESTS=1
+
+use cadmus_server::db::Database;
+use cadmus_server::documents::storage::SnapshotStorage;
+use cadmus_server::{build_router, AppState};
+use std::sync::Arc;
+use tokio::net::TcpListener;
+
+fn should_skip() -> bool {
+    std::env::var("SKIP_PERSISTENCE_TESTS").is_ok()
+}
+
+fn database_url() -> String {
+    std::env::var("DATABASE_URL").unwrap_or_else(|_| "postgres://localhost/cadmus_test".to_string())
+}
+
+fn s3_endpoint() -> String {
+    std::env::var("S3_ENDPOINT").unwrap_or_else(|_| "http://localhost:4566".to_string())
+}
+
+const S3_BUCKET: &str = "cadmus-documents";
+
+async fn spawn_test_server() -> Option<String> {
+    if should_skip() {
+        return None;
+    }
+
+    let db = match Database::connect(&database_url()).await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping auth test — cannot connect to database: {e}");
+            return None;
+        }
+    };
+
+    if let Err(e) = sqlx::migrate!().run(&db.pool).await {
+        eprintln!("Skipping auth test — migration failed: {e}");
+        return None;
+    }
+
+    let storage = SnapshotStorage::new(S3_BUCKET, Some(&s3_endpoint())).await;
+
+    let state = Arc::new(AppState {
+        db,
+        document_sessions: Arc::new(cadmus_server::documents::SessionManager::new()),
+        storage,
+        sidecar: cadmus_server::sidecar::SidecarClient::new("http://localhost:3001"),
+        config: cadmus_server::config::Config {
+            database_url: database_url(),
+            sidecar_url: "http://localhost:3001".to_string(),
+            jwt_secret: "test-secret".to_string(),
+            s3_bucket: S3_BUCKET.to_string(),
+            s3_endpoint: Some(s3_endpoint()),
+            port: 0,
+        },
+    });
+
+    let app = build_router(state);
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    Some(format!("http://127.0.0.1:{}", addr.port()))
+}
+
+/// Generate a unique email for test isolation.
+fn unique_email() -> String {
+    format!("test-{}@example.com", uuid::Uuid::new_v4())
+}
+
+#[tokio::test]
+async fn test_register_new_user() {
+    let Some(base_url) = spawn_test_server().await else {
+        return;
+    };
+
+    let client = reqwest::Client::new();
+    let email = unique_email();
+
+    let resp = client
+        .post(format!("{base_url}/api/auth/register"))
+        .json(&serde_json::json!({
+            "email": email,
+            "display_name": "Alice",
+            "password": "securepassword123"
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 201);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["user"]["email"], email);
+    assert_eq!(body["user"]["display_name"], "Alice");
+    assert!(body["user"]["id"].is_string());
+    assert!(body["access_token"].is_string());
+    assert!(body["refresh_token"].is_string());
+    assert_eq!(body["expires_in"], 900);
+}
+
+#[tokio::test]
+async fn test_register_duplicate_email() {
+    let Some(base_url) = spawn_test_server().await else {
+        return;
+    };
+
+    let client = reqwest::Client::new();
+    let email = unique_email();
+
+    // Register first time
+    client
+        .post(format!("{base_url}/api/auth/register"))
+        .json(&serde_json::json!({
+            "email": email,
+            "display_name": "Alice",
+            "password": "securepassword123"
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    // Register again with same email
+    let resp = client
+        .post(format!("{base_url}/api/auth/register"))
+        .json(&serde_json::json!({
+            "email": email,
+            "display_name": "Bob",
+            "password": "anotherpassword123"
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 409);
+}
+
+#[tokio::test]
+async fn test_register_invalid_fields() {
+    let Some(base_url) = spawn_test_server().await else {
+        return;
+    };
+
+    let client = reqwest::Client::new();
+
+    // Missing @ in email
+    let resp = client
+        .post(format!("{base_url}/api/auth/register"))
+        .json(&serde_json::json!({
+            "email": "not-an-email",
+            "display_name": "Alice",
+            "password": "securepassword123"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+
+    // Short password
+    let resp = client
+        .post(format!("{base_url}/api/auth/register"))
+        .json(&serde_json::json!({
+            "email": unique_email(),
+            "display_name": "Alice",
+            "password": "short"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+}
+
+#[tokio::test]
+async fn test_login_valid_credentials() {
+    let Some(base_url) = spawn_test_server().await else {
+        return;
+    };
+
+    let client = reqwest::Client::new();
+    let email = unique_email();
+
+    // Register
+    client
+        .post(format!("{base_url}/api/auth/register"))
+        .json(&serde_json::json!({
+            "email": email,
+            "display_name": "Alice",
+            "password": "securepassword123"
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    // Login
+    let resp = client
+        .post(format!("{base_url}/api/auth/login"))
+        .json(&serde_json::json!({
+            "email": email,
+            "password": "securepassword123"
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["user"]["email"], email);
+    assert!(body["access_token"].is_string());
+    assert!(body["refresh_token"].is_string());
+}
+
+#[tokio::test]
+async fn test_login_wrong_password() {
+    let Some(base_url) = spawn_test_server().await else {
+        return;
+    };
+
+    let client = reqwest::Client::new();
+    let email = unique_email();
+
+    // Register
+    client
+        .post(format!("{base_url}/api/auth/register"))
+        .json(&serde_json::json!({
+            "email": email,
+            "display_name": "Alice",
+            "password": "securepassword123"
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    // Login with wrong password
+    let resp = client
+        .post(format!("{base_url}/api/auth/login"))
+        .json(&serde_json::json!({
+            "email": email,
+            "password": "wrongpassword123"
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 401);
+}
+
+#[tokio::test]
+async fn test_login_nonexistent_email() {
+    let Some(base_url) = spawn_test_server().await else {
+        return;
+    };
+
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .post(format!("{base_url}/api/auth/login"))
+        .json(&serde_json::json!({
+            "email": "nobody@example.com",
+            "password": "securepassword123"
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 401);
+}
+
+#[tokio::test]
+async fn test_refresh_valid_token() {
+    let Some(base_url) = spawn_test_server().await else {
+        return;
+    };
+
+    let client = reqwest::Client::new();
+    let email = unique_email();
+
+    // Register and get tokens
+    let resp = client
+        .post(format!("{base_url}/api/auth/register"))
+        .json(&serde_json::json!({
+            "email": email,
+            "display_name": "Alice",
+            "password": "securepassword123"
+        }))
+        .send()
+        .await
+        .unwrap();
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let refresh_token = body["refresh_token"].as_str().unwrap();
+
+    // Refresh
+    let resp = client
+        .post(format!("{base_url}/api/auth/refresh"))
+        .json(&serde_json::json!({ "refresh_token": refresh_token }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert!(body["access_token"].is_string());
+    assert_eq!(body["expires_in"], 900);
+}
+
+#[tokio::test]
+async fn test_refresh_invalid_token() {
+    let Some(base_url) = spawn_test_server().await else {
+        return;
+    };
+
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .post(format!("{base_url}/api/auth/refresh"))
+        .json(&serde_json::json!({ "refresh_token": "invalid-token" }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 401);
+}
+
+#[tokio::test]
+async fn test_me_with_valid_token() {
+    let Some(base_url) = spawn_test_server().await else {
+        return;
+    };
+
+    let client = reqwest::Client::new();
+    let email = unique_email();
+
+    // Register
+    let resp = client
+        .post(format!("{base_url}/api/auth/register"))
+        .json(&serde_json::json!({
+            "email": email,
+            "display_name": "Alice",
+            "password": "securepassword123"
+        }))
+        .send()
+        .await
+        .unwrap();
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let access_token = body["access_token"].as_str().unwrap();
+
+    // GET /me
+    let resp = client
+        .get(format!("{base_url}/api/auth/me"))
+        .header("Authorization", format!("Bearer {access_token}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 200);
+    let profile: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(profile["email"], email);
+    assert_eq!(profile["display_name"], "Alice");
+}
+
+#[tokio::test]
+async fn test_me_without_token() {
+    let Some(base_url) = spawn_test_server().await else {
+        return;
+    };
+
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .get(format!("{base_url}/api/auth/me"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 401);
+}

--- a/packages/server/tests/persistence_test.rs
+++ b/packages/server/tests/persistence_test.rs
@@ -62,7 +62,7 @@ async fn test_document_persists_across_restart() {
 
     // Create a document in the database
     let doc_id = Uuid::new_v4();
-    db.create_document(doc_id, "Persistence Test")
+    db.create_document(doc_id, "Persistence Test", None)
         .await
         .expect("failed to create document");
 
@@ -128,7 +128,7 @@ async fn test_update_log_crash_recovery() {
 
     // Create a document
     let doc_id = Uuid::new_v4();
-    db.create_document(doc_id, "Crash Recovery Test")
+    db.create_document(doc_id, "Crash Recovery Test", None)
         .await
         .expect("failed to create document");
 
@@ -195,7 +195,7 @@ async fn test_flush_clears_update_log() {
 
     // Create a document
     let doc_id = Uuid::new_v4();
-    db.create_document(doc_id, "Flush Clears Log Test")
+    db.create_document(doc_id, "Flush Clears Log Test", None)
         .await
         .expect("failed to create document");
 


### PR DESCRIPTION
## Summary

- Add `users` table with Argon2id password hashing, plus `created_by` FK on documents and user FK on document_permissions
- Implement five auth endpoints: `POST /api/auth/register`, `POST /api/auth/login`, `POST /api/auth/refresh`, `POST /api/auth/ws-token`, `GET /api/auth/me`
- JWT tokens with distinct types (access/refresh/ws) and appropriate expiry times (15min/7d/30s)

## Test plan

- [x] 7 unit tests for password hashing (3) and JWT (4) — all pass
- [x] 10 integration tests covering register, login, refresh, me, and error cases — all pass
- [x] 13 pre-existing tests continue to pass (document CRUD, persistence, WebSocket)
- [x] `cargo build` succeeds
- [x] `pnpm run format:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)