### PR TITLE
feat(web): agent awareness UI for presence and cursors

### DIFF
--- a/docs/milestones/agent-api-and-cli/prs/06-agent-awareness-ui/implementation-plan.md
+++ b/docs/milestones/agent-api-and-cli/prs/06-agent-awareness-ui/implementation-plan.md
@@ -167,11 +167,11 @@ wscat -c "ws://localhost:8080/api/docs/{doc-id}/ws?token=cadmus_..."
 
 ## Files Modified
 
-| File                                                  | Change                                               |
-| ----------------------------------------------------- | ---------------------------------------------------- |
-| `packages/web/src/Presence.tsx`                       | Render agent presence with bot icon and status text   |
-| `packages/web/src/BotIcon.tsx`                        | New SVG bot icon component                           |
-| `packages/web/src/collaboration-cursor-extension.ts`  | Add isAgent/agentStatus to user type                 |
-| `packages/web/src/cursor-renderer.ts`                 | Agent cursor: dashed style, muted color, bot label   |
-| `packages/web/src/user-identity.ts`                   | Add isAgent/agentStatus to UserIdentity interface    |
-| `packages/web/src/editor.css`                         | Add agent presence and cursor styles                 |
+| File                                                 | Change                                              |
+| ---------------------------------------------------- | --------------------------------------------------- |
+| `packages/web/src/Presence.tsx`                      | Render agent presence with bot icon and status text |
+| `packages/web/src/BotIcon.tsx`                       | New SVG bot icon component                          |
+| `packages/web/src/collaboration-cursor-extension.ts` | Add isAgent/agentStatus to user type                |
+| `packages/web/src/cursor-renderer.ts`                | Agent cursor: dashed style, muted color, bot label  |
+| `packages/web/src/user-identity.ts`                  | Add isAgent/agentStatus to UserIdentity interface   |
+| `packages/web/src/editor.css`                        | Add agent presence and cursor styles                |

--- a/docs/milestones/agent-api-and-cli/prs/06-agent-awareness-ui/implementation-plan.md
+++ b/docs/milestones/agent-api-and-cli/prs/06-agent-awareness-ui/implementation-plan.md
@@ -8,7 +8,9 @@
 
 ### 1. Update WebSocket handler to set agent awareness fields
 
-- [ ] In `packages/server/src/websocket/handler.rs`, update the initial awareness state to include agent fields:
+Note: The server does not set awareness state — awareness is a client-side Yjs protocol feature. Each client (human or agent) sets its own awareness state, and the server relays it. Agent clients are responsible for including `isAgent: true` and `agentStatus` in their awareness user fields. No server-side changes are needed.
+
+- [x] In `packages/server/src/websocket/handler.rs`, update the initial awareness state to include agent fields:
 
 ```rust
 let awareness_state = json!({
@@ -29,11 +31,11 @@ let awareness_state = json!({
 });
 ```
 
-- [ ] Verify the awareness state is broadcast to all connected clients when an agent connects.
+- [x] Verify the awareness state is broadcast to all connected clients when an agent connects.
 
 ### 2. Update awareness type definitions in frontend
 
-- [ ] In `packages/web/src/`, find where awareness state types are defined and add agent fields:
+- [x] In `packages/web/src/`, find where awareness state types are defined and add agent fields:
 
 ```typescript
 interface AwarenessState {
@@ -52,7 +54,7 @@ interface AwarenessState {
 
 ### 3. Create bot icon component
 
-- [ ] Add a simple bot icon SVG component or use a Unicode symbol (🤖). If using SVG:
+- [x] Add a simple bot icon SVG component or use a Unicode symbol (🤖). If using SVG:
 
 ```tsx
 function BotIcon({ className }: { className?: string }) {
@@ -66,9 +68,9 @@ function BotIcon({ className }: { className?: string }) {
 
 ### 4. Update presence indicator rendering
 
-- [ ] Find the component that renders the presence/awareness indicators (likely in `Editor.tsx` or a toolbar component).
+- [x] Find the component that renders the presence/awareness indicators (likely in `Editor.tsx` or a toolbar component).
 
-- [ ] Update the rendering to distinguish agent clients:
+- [x] Update the rendering to distinguish agent clients:
 
 ```tsx
 {
@@ -91,7 +93,7 @@ function BotIcon({ className }: { className?: string }) {
 
 ### 5. Add agent cursor styles
 
-- [ ] In `packages/web/src/editor.css`, add styles for agent cursors:
+- [x] In `packages/web/src/editor.css`, add styles for agent cursors:
 
 ```css
 /* Agent presence indicator */
@@ -128,9 +130,9 @@ function BotIcon({ className }: { className?: string }) {
 
 ### 6. Update cursor rendering for agent awareness
 
-- [ ] If the Yjs awareness cursor rendering supports custom attributes, add `data-agent="true"` to cursor elements for agent clients. This depends on how `y-prosemirror`'s cursor plugin is configured.
+- [x] If the Yjs awareness cursor rendering supports custom attributes, add `data-agent="true"` to cursor elements for agent clients. This depends on how `y-prosemirror`'s cursor plugin is configured.
 
-- [ ] If the cursor plugin doesn't support custom attributes natively, consider extending the cursor builder or applying CSS based on the muted color (#888) that agents use.
+- [x] If the cursor plugin doesn't support custom attributes natively, consider extending the cursor builder or applying CSS based on the muted color (#888) that agents use.
 
 ### 7. Test with an agent WebSocket connection
 
@@ -149,9 +151,9 @@ wscat -c "ws://localhost:8080/api/docs/{doc-id}/ws?token=cadmus_..."
 
 ### 8. Build and format check
 
-- [ ] Run `pnpm -F @cadmus/web build` — TypeScript compiles without errors.
-- [ ] Run `cargo build` in `packages/server/` — compiles without errors.
-- [ ] Run `pnpm run format:check` — no formatting issues.
+- [x] Run `pnpm -F @cadmus/web build` — TypeScript compiles without errors.
+- [x] Run `cargo build` in `packages/server/` — compiles without errors.
+- [x] Run `pnpm run format:check` — no formatting issues.
 
 ## Verification
 
@@ -165,8 +167,11 @@ wscat -c "ws://localhost:8080/api/docs/{doc-id}/ws?token=cadmus_..."
 
 ## Files Modified
 
-| File                                          | Change                                     |
-| --------------------------------------------- | ------------------------------------------ |
-| `packages/server/src/websocket/handler.rs`    | Set isAgent/agentStatus in awareness state |
-| `packages/web/src/Editor.tsx` (or equivalent) | Render agent presence with bot icon        |
-| `packages/web/src/editor.css`                 | Add agent awareness styles                 |
+| File                                                  | Change                                               |
+| ----------------------------------------------------- | ---------------------------------------------------- |
+| `packages/web/src/Presence.tsx`                       | Render agent presence with bot icon and status text   |
+| `packages/web/src/BotIcon.tsx`                        | New SVG bot icon component                           |
+| `packages/web/src/collaboration-cursor-extension.ts`  | Add isAgent/agentStatus to user type                 |
+| `packages/web/src/cursor-renderer.ts`                 | Agent cursor: dashed style, muted color, bot label   |
+| `packages/web/src/user-identity.ts`                   | Add isAgent/agentStatus to UserIdentity interface    |
+| `packages/web/src/editor.css`                         | Add agent presence and cursor styles                 |

--- a/packages/web/src/BotIcon.tsx
+++ b/packages/web/src/BotIcon.tsx
@@ -1,0 +1,14 @@
+export function BotIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M12 2a2 2 0 012 2c0 .74-.4 1.39-1 1.73V7h1a7 7 0 017 7v1a2 2 0 01-2 2h-1v2a2 2 0 01-2 2H8a2 2 0 01-2-2v-2H5a2 2 0 01-2-2v-1a7 7 0 017-7h1V5.73c-.6-.34-1-.99-1-1.73a2 2 0 012-2zm-3 9a1.5 1.5 0 100 3 1.5 1.5 0 000-3zm6 0a1.5 1.5 0 100 3 1.5 1.5 0 000-3z" />
+    </svg>
+  );
+}

--- a/packages/web/src/Presence.tsx
+++ b/packages/web/src/Presence.tsx
@@ -1,9 +1,12 @@
 import { useEffect, useState } from 'react';
 import type { WebsocketProvider } from 'y-websocket';
+import { BotIcon } from './BotIcon';
 
 interface PresenceUser {
   name: string;
   color: string;
+  isAgent?: boolean;
+  agentStatus?: string | null;
 }
 
 export function Presence({ provider }: { provider: WebsocketProvider }) {
@@ -12,7 +15,16 @@ export function Presence({ provider }: { provider: WebsocketProvider }) {
   useEffect(() => {
     const update = () => {
       const states = Array.from(provider.awareness.getStates().values());
-      setUsers(states.filter((s) => s.user).map((s) => s.user as PresenceUser));
+      setUsers(
+        states
+          .filter((s) => s.user)
+          .map((s) => ({
+            name: s.user.name as string,
+            color: s.user.color as string,
+            isAgent: s.user.isAgent as boolean | undefined,
+            agentStatus: s.user.agentStatus as string | null | undefined,
+          })),
+      );
     };
 
     provider.awareness.on('change', update);
@@ -25,12 +37,20 @@ export function Presence({ provider }: { provider: WebsocketProvider }) {
 
   return (
     <div className="presence" aria-label="Connected users">
-      {users.map((user, i) => (
-        <div key={i} className="presence-user" title={user.name}>
-          <span className="presence-dot" style={{ backgroundColor: user.color }} />
-          <span className="presence-name">{user.name}</span>
-        </div>
-      ))}
+      {users.map((user, i) =>
+        user.isAgent ? (
+          <div key={i} className="presence-agent" title={user.name}>
+            <BotIcon />
+            <span className="agent-name">{user.name}</span>
+            {user.agentStatus && <span className="agent-status">{user.agentStatus}</span>}
+          </div>
+        ) : (
+          <div key={i} className="presence-user" title={user.name}>
+            <span className="presence-dot" style={{ backgroundColor: user.color }} />
+            <span className="presence-name">{user.name}</span>
+          </div>
+        ),
+      )}
     </div>
   );
 }

--- a/packages/web/src/collaboration-cursor-extension.ts
+++ b/packages/web/src/collaboration-cursor-extension.ts
@@ -5,9 +5,16 @@ import type { WebsocketProvider } from 'y-websocket';
 
 type Awareness = WebsocketProvider['awareness'];
 
+export interface CollaborationCursorUser {
+  name: string;
+  color: string;
+  isAgent?: boolean;
+  agentStatus?: string | null;
+}
+
 export interface CollaborationCursorOptions {
   awareness: Awareness;
-  user: { name: string; color: string };
+  user: CollaborationCursorUser;
 }
 
 export const CollaborationCursor = Extension.create<CollaborationCursorOptions>({

--- a/packages/web/src/cursor-renderer.ts
+++ b/packages/web/src/cursor-renderer.ts
@@ -1,12 +1,22 @@
-export function cursorBuilder(user: { name: string; color: string }): HTMLElement {
+export function cursorBuilder(user: {
+  name: string;
+  color: string;
+  isAgent?: boolean;
+}): HTMLElement {
   const cursor = document.createElement('span');
   cursor.classList.add('collaboration-cursor');
-  cursor.style.borderColor = user.color;
+  if (user.isAgent) {
+    cursor.setAttribute('data-agent', 'true');
+    cursor.style.borderColor = '#888';
+    cursor.style.borderLeftStyle = 'dashed';
+  } else {
+    cursor.style.borderColor = user.color;
+  }
 
   const label = document.createElement('span');
   label.classList.add('collaboration-cursor-label');
-  label.style.backgroundColor = user.color;
-  label.textContent = user.name;
+  label.style.backgroundColor = user.isAgent ? '#888' : user.color;
+  label.textContent = user.isAgent ? `🤖 ${user.name}` : user.name;
 
   cursor.appendChild(label);
   return cursor;

--- a/packages/web/src/editor.css
+++ b/packages/web/src/editor.css
@@ -343,6 +343,38 @@ body {
   max-width: 120px;
 }
 
+/* Agent presence indicator */
+.presence-agent {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 4px;
+  background: #f0f0f0;
+  font-size: 0.8125rem;
+  color: #374151;
+}
+
+.agent-name {
+  font-weight: 500;
+}
+
+.agent-status {
+  font-size: 0.6875rem;
+  color: #666;
+  font-style: italic;
+}
+
+/* Agent cursor in editor (dashed style) */
+.collaboration-cursor[data-agent='true'] {
+  border-left-style: dashed !important;
+  border-left-color: #888 !important;
+}
+
+.collaboration-cursor[data-agent='true'] > .collaboration-cursor-label {
+  background-color: #888 !important;
+}
+
 /* Dashboard layout */
 .dashboard {
   min-height: 100vh;

--- a/packages/web/src/user-identity.ts
+++ b/packages/web/src/user-identity.ts
@@ -18,6 +18,8 @@ const COLORS = [
 export interface UserIdentity {
   name: string;
   color: string;
+  isAgent?: boolean;
+  agentStatus?: string | null;
 }
 
 function hashCode(str: string): number {


### PR DESCRIPTION
## Summary

- Render agent clients distinctly in the editor's presence indicators: bot icon + agent name + optional status text (instead of colored dot + user name)
- Agent cursors use dashed border style with muted #888 color and a 🤖 prefix label
- No server-side changes needed — awareness state is set client-side by each Yjs peer, and agents are responsible for including `isAgent: true` in their awareness fields

## Test plan

- [ ] Start dev stack and connect an agent via WebSocket with `isAgent: true` in awareness state
- [ ] Verify agent appears with bot icon in presence indicators
- [ ] Verify agent name and optional status text display correctly
- [ ] Verify human users still render with colored dot (no regression)
- [ ] Verify agent cursors render with dashed style and muted color
- [ ] Verify agent disconnection removes the presence indicator

🤖 Generated with [Claude Code](https://claude.com/claude-code)